### PR TITLE
Add easy way of getting secret at key as string

### DIFF
--- a/pkg/hashivault/doc.go
+++ b/pkg/hashivault/doc.go
@@ -128,13 +128,21 @@ import (
 			}
 		}(errChan)
 
+		// Get a map of several secrets.
 		secret, err := v.GetSecret(ctx, "kunde/kv/data/appinsights/kunde")
 		if err != nil {
 			log.Fatal(err)
 		}
 
+		// Supports dynamic secrets, i.e. when calling the function `secret`, the latest version of the secret is returned.
 		mapOfSecrets := secret()
 		_ = mapOfSecrets
+
+		// Get a single (static) secret at a given key.
+		staticSecret, err := v.GetStaticSecretAtKey(ctx, "kunde/kv/data/appinsights/kunde", "connection_string")
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
 
 ```

--- a/pkg/hashivault/manager.go
+++ b/pkg/hashivault/manager.go
@@ -56,6 +56,25 @@ func (m *manager) GetSecret(ctx context.Context, path string) (EvergreenSecretsF
 	return es.get, nil
 }
 
+func (m *manager) GetSecretAtKey(ctx context.Context, path, key string) (string, error) {
+	secret, err := m.GetSecret(ctx, path)
+	if err != nil {
+		return "", err
+	}
+
+	secretMap := secret()
+	if _, ok := secretMap[key]; !ok {
+		return "", fmt.Errorf("key %s not found in secret map", key)
+	}
+
+	secretString, ok := secretMap[key].(string)
+	if !ok {
+		return "", fmt.Errorf("could not convert secret at key %s to string", key)
+	}
+
+	return secretString, nil
+}
+
 func (m *manager) SetDefaultGoogleCredentials(ctx context.Context, path, key string) error {
 	m.l.Print("setting default google credentials")
 

--- a/pkg/hashivault/manager.go
+++ b/pkg/hashivault/manager.go
@@ -56,6 +56,8 @@ func (m *manager) GetSecret(ctx context.Context, path string) (EvergreenSecretsF
 	return es.get, nil
 }
 
+// Wrapper around GetSecret that gets only a single secret at the given key.
+// NOTE: If you have dynamic secrets that might change, you should use GetSecret and call the returned function every time you need the secret.
 func (m *manager) GetSecretAtKey(ctx context.Context, path, key string) (string, error) {
 	secret, err := m.GetSecret(ctx, path)
 	if err != nil {

--- a/pkg/hashivault/manager.go
+++ b/pkg/hashivault/manager.go
@@ -58,7 +58,7 @@ func (m *manager) GetSecret(ctx context.Context, path string) (EvergreenSecretsF
 
 // Wrapper around GetSecret that gets only a single secret at the given key.
 // NOTE: If you have dynamic secrets that might change, you should use GetSecret and call the returned function every time you need the secret.
-func (m *manager) GetSecretAtKey(ctx context.Context, path, key string) (string, error) {
+func (m *manager) GetStaticSecretAtKey(ctx context.Context, path, key string) (string, error) {
 	secret, err := m.GetSecret(ctx, path)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Jeg synes det er veldig tungvint å hente ut en enkel secret på en key hvis man skal error-checke alt, så foreslår en funksjon som gjør dette mye enklere.

Gammel måte:
```go
secret, err := vaultClient.GetSecret(
	ctx,
	"core/kv/data/my-app/my-secret",
)
if err != nil {
	log.Fatal(err)
}

secretMap := secret()

secretString, err := func() (string, error) {
	if len(secretMap) == 0 {
		return "", errors.New("secret map is empty")
	}

	if secretAtKey, ok := secretMap["my-key"].(string); ok {
		return secretAtKey, nil
	}

	return "", fmt.Errorf("no secret found at key %s", "my-key")
}()
if err != nil {
	log.Fatal(err)
}
```

Ny måte:
```go
secretString, err := vaultClient.GetSecretAtKey(
	ctx,
	"core/kv/data/my-app/my-secret",
	"my-key",
)
if err != nil {
	log.Fatal("no secret found")
}
```